### PR TITLE
Fix for missing gas measurement in Homey Energy tab Issue #73

### DIFF
--- a/app.json
+++ b/app.json
@@ -377,14 +377,14 @@
         ]
       },
       {
-        "id": "meter_gas.current.changed",
+        "id": "meter_gas.changed",
         "title": {
           "nl": "Gasverbruik is veranderd",
           "en": "Gas usage has changed"
         },
         "tokens": [
           {
-            "name": "meter_gas.current",
+            "name": "meter_gas",
             "type": "number",
             "title": {
               "en": "Gas usage (m³)",
@@ -910,7 +910,7 @@
         "measure_power",
         "meter_power.consumedL1",
         "meter_power.consumedL2",
-        "meter_gas.current",
+        "meter_gas",
         "tariff_high",
         "version_number"
       ],
@@ -941,7 +941,7 @@
           "decimals": 3,
           "color": "#c2ad38"
         },
-        "meter_gas.current": {
+        "meter_gas": {
           "title": {
             "nl": "Gasverbruik",
             "en": "Gas usage"

--- a/drivers/ztatz_p1_Usage/device.js
+++ b/drivers/ztatz_p1_Usage/device.js
@@ -49,15 +49,15 @@ module.exports = class ztatzP1SmartMeterDevice extends Device {
 			this.addCapability('meter_power.consumedL1');
 		}
 
-		if(!this.hasCapability('meter_gas.current')){
-			this.addCapability('meter_gas.current');
+		if(!this.hasCapability('meter_gas')){
+			this.addCapability('meter_gas');
 		}
 
 		console.log("register flow triggers");
 		// register Flow triggers
 		this._flowTriggerPowerMeterL1Changed = this.homey.flow.getDeviceTriggerCard('meter_power.consumedL1.changed');
 		this._flowTriggerPowerMeterL2Changed = this.homey.flow.getDeviceTriggerCard('meter_power.consumedL2.changed');
-		this._flowTriggerGasMeterChanged = this.homey.flow.getDeviceTriggerCard('meter_gas.current.changed');
+		this._flowTriggerGasMeterChanged = this.homey.flow.getDeviceTriggerCard('meter_gas.changed');
 		this._flowTriggerVersionChanged = this.homey.flow.getDeviceTriggerCard('version_number.changed');
 
 		this._syncStats();
@@ -107,7 +107,7 @@ module.exports = class ztatzP1SmartMeterDevice extends Device {
 				this.changeCapabilityValue('measure_power', Number(currentUsage));
 				this.changeCapabilityValue('meter_power.consumedL2', Number(usageLow), this._flowTriggerPowerMeterL2Changed, {'meter_power.consumedL2':Number(usageLow)});
 				this.changeCapabilityValue('meter_power.consumedL1', Number(usageHigh), this._flowTriggerPowerMeterL1Changed, {'meter_power.consumedL1':Number(usageHigh)});
-				this.changeCapabilityValue('meter_gas.current', Number(currentGas), this._flowTriggerGasMeterChanged, {'meter_gas.current':Number(currentGas)});
+				this.changeCapabilityValue('meter_gas', Number(currentGas), this._flowTriggerGasMeterChanged, {'meter_gas':Number(currentGas)});
 
 				let tariff_high = false;
 

--- a/drivers/ztatz_p1_Usage/driver.compose.json
+++ b/drivers/ztatz_p1_Usage/driver.compose.json
@@ -8,7 +8,7 @@
     "measure_power",
     "meter_power.consumedL1",
     "meter_power.consumedL2",
-    "meter_gas.current",
+    "meter_gas",
     "tariff_high",
     "version_number"
   ],
@@ -39,7 +39,7 @@
       "decimals": 3,
       "color": "#c2ad38"
     },
-    "meter_gas.current": {
+    "meter_gas": {
       "title": {
         "nl": "Gasverbruik",
         "en": "Gas usage"

--- a/drivers/ztatz_p1_Usage/driver.flow.compose.json
+++ b/drivers/ztatz_p1_Usage/driver.flow.compose.json
@@ -95,14 +95,14 @@
       "args": []
     },
     {
-      "id": "meter_gas.current.changed",
+      "id": "meter_gas.changed",
       "title": {
         "nl": "Gasverbruik is veranderd",
         "en": "Gas usage has changed"
       },
       "tokens": [
         {
-          "name": "meter_gas.current",
+          "name": "meter_gas",
           "type": "number",
           "title": {
             "en": "Gas usage (m³)",


### PR DESCRIPTION
By removing the "current" suffix from the gas measurments the Homey Energy tab now correctly shows the Gas consumption and shows a nice graph.

The Smart meter doesn't provide any "current" or actual usage of gas (the flow throughput is probably too low or difficult to properly measure over the full range). Therefor it provides the meter count on a minute and hourly rate. Homey shows this in a graph (similar to how ZTATZ this also does).